### PR TITLE
Only set crossOrigin if the user provides the option

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -10,7 +10,9 @@ function Tile(url, x, y, z, options) {
 
 Tile.prototype.load = function(callback) {
   var image = new Image();
-  image.crossOrigin = this.options.crossOrigin || 'anonymous';
+  if (this.options.crossOrigin) {
+    image.crossOrigin = this.options.crossOrigin;
+  }
   image.width = xyz.SIZE;
   image.height = xyz.SIZE;
   this.image = image;


### PR DESCRIPTION
This makes the `crossOrigin` option opt-in instead of setting it to 'anonymous' by default.