### PR TITLE
Accept URL templates with numeric or character ranges

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -17,14 +17,9 @@
       function createMap(geoJson) {
         var map = stickymap({
           clip: geoJson,
-          width: 600,
+          width: 500,
           layers: [{
-            urls: [
-              'https://a.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png',
-              'https://b.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png',
-              'https://c.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png',
-              'https://d.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png'
-            ]
+            url: 'https://{a-d}.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png'
           }]
         });
 

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,53 @@
 # stickymap
 
-Sticky maps.
+Sticky maps are maps that are not slippy maps.  Meaning, if you want to use tiles or imagery that are typically rendered in a slippy map, but you don't need users to be able to interact with the rendered map, create a sticky map.
 
-# the rough idea
+For example, if you wanted to embed a map of the state of Montana in a web page using imagery from Mapbox, you could do this:
 
 ```js
 var map = stickymap({
-  fit: [-120, 40, -100, 60],
-  layers: [
-    {url: 'http://example.com/{z}/{x}/{y}.png'}
-  ],
-  width: 200
+  width: 500,
+  clip: geoJson, // <- GeoJSON representing the state of Montana
+  layers: [{
+    url: 'https://{a-d}.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png'
+  }]
 });
 
-document.body.appendChild(map);
+document.body.appendChild(map); // map is a Canvas element
 ```
+![sticky map](https://cloud.githubusercontent.com/assets/41094/22658668/230c3834-ec58-11e6-8cc4-99314378075f.png)
+
+## API
+
+The `stickymap` function takes a map configuration and returns a `Canvas` element with the rendered map.  The map configuration properties are described below.
+
+### `width`
+
+The width (in pixels) of the map.  Either `width` or `height` (or both) must be provided.
+
+### `height`
+
+The height (in pixels) of the map.  Either `width` or `height` (or both) must be provided.
+
+### `fit`
+
+A GeoJSON object (of any type) or bounding box ([minLon, minLat, maxLon, maxLat] array) that will be used to calculate the extent of the map.  Either `fit` or `clip` must be provided.
+
+### `clip`
+
+A GeoJSON object (of any type) used as a clip path when rendering the map.  Areas outside `clip` will not be rendered.
+
+### `layers`
+
+An array of layer configurations.  Layers are rendered from tiled imagery or from a single image.
+
+#### Tiled layer properties
+
+Tiled layers must have a `url` or `urls` property.  An array of `urls` can be provided to fetch tiles from more than one subdomain (for example).  URLs must include `{x}`, `{y}`, and `{z}` placeholders.  If a single `url` is provided, it can include a range of numbers or characters that will be used to expand the URL into an array of URLs (`{0-4}` or `{a-d}` for example).
+
+#### Untiled layer properties
+
+Layers can be rendered from a single image by setting `untiled: true`.  Untiled layers must have a `bbox` property that describes the bounding box (`[minLon, minLat, maxLon, maxLat]`) of the image.  In addition, untiled layers must have a `url` property with the URL of the image to be rendered.
+
 
 [![Build Status](https://travis-ci.org/tschaub/stickymap.svg?branch=master)](https://travis-ci.org/tschaub/stickymap)

--- a/src/map.js
+++ b/src/map.js
@@ -64,12 +64,16 @@ function StickyMap(config) {
           layerBbox = geo.getBbox(layerBbox);
         }
       }
+      var urls = layerConfig.urls;
+      if (!urls) {
+        urls = util.expandUrl(layerConfig.url);
+      }
       return new TileLayer({
         context: context,
         resolution: dimensions.resolution,
         bbox: bbox,
         layerBbox: layerBbox ? merc.forward(layerBbox) : bbox,
-        urls: layerConfig.urls || [layerConfig.url],
+        urls: urls,
         onTileLoad: render
       });
     }

--- a/src/util.js
+++ b/src/util.js
@@ -30,3 +30,23 @@ exports.resolveDimensions = function(config) {
     height: height
   };
 };
+
+var URL_RANGE = /{([0-9a-zA-Z])-([0-9a-zA-Z])}/;
+exports.expandUrl = function(url) {
+  var urls;
+  var match = url.match(URL_RANGE);
+  if (match) {
+    var start = match[1].charCodeAt(0);
+    var end = match[2].charCodeAt(0);
+    if (!(end > start)) {
+      throw new Error('Invalid range in URL template: ' + match[1] + '-' + match[2]);
+    }
+    urls = [];
+    for (var i = start; i <= end; ++i) {
+      urls.push(url.replace(match[0], String.fromCharCode(i)));
+    }
+  } else {
+    urls = [url];
+  }
+  return urls;
+};

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -85,3 +85,47 @@ describe('resolveDimensions', function() {
     expect(dimensions.bbox).to.eql([0, -1000, 1000, 3000]);
   });
 });
+
+describe('expandUrl()', function() {
+
+  var cases = [{
+    url: 'https://www{0-4}.example.com',
+    urls: [
+      'https://www0.example.com',
+      'https://www1.example.com',
+      'https://www2.example.com',
+      'https://www3.example.com',
+      'https://www4.example.com'
+    ]
+  }, {
+    url: 'https://tiles-{a-d}.example.com/{z}/{x}/{y}.png',
+    urls: [
+      'https://tiles-a.example.com/{z}/{x}/{y}.png',
+      'https://tiles-b.example.com/{z}/{x}/{y}.png',
+      'https://tiles-c.example.com/{z}/{x}/{y}.png',
+      'https://tiles-d.example.com/{z}/{x}/{y}.png'
+    ]
+  }];
+
+  for (var i = 0, ii = cases.length; i < ii; ++i) {
+    var c = cases[i];
+    it('works for ' + c.url, function() {
+      expect(util.expandUrl(c.url)).to.eql(c.urls);
+    });
+  }
+
+  it('throws for an invalid numeric range', function() {
+    var call = function() {
+      return util.expandUrl('https://tiles-{4-0}.example.com');
+    };
+    expect(call).throws('Invalid range in URL template: 4-0');
+  });
+
+  it('throws for an invalid character range', function() {
+    var call = function() {
+      return util.expandUrl('https://tiles-{z-a}.example.com');
+    };
+    expect(call).throws('Invalid range in URL template: z-a');
+  });
+
+});


### PR DESCRIPTION
This makes it so a map can be configured with a single URL that expands to an array of URLs.

For example:
```js
var map = stickymap({
  clip: geoJson,
  width: 600,
  layers: [{
    url: 'https://{a-d}.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png'
  }]
});
```

Is equivalent to:
```js
var map = stickymap({
  clip: geoJson,
  width: 600,
  layers: [{
    urls: [
      'https://a.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png',
      'https://b.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png',
      'https://c.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png',
      'https://d.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jul/{z}/{x}/{y}.png'
    ]
  }]
});
```