### PR TITLE
Accept a callback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,10 @@ A GeoJSON object (of any type) or bounding box ([minLon, minLat, maxLon, maxLat]
 
 A GeoJSON object (of any type) used as a clip path when rendering the map.  Areas outside `clip` will not be rendered.
 
+### `onLoad`
+
+Optional callback that will be called when the map finishes rendering.  The callback will be called with an `Error` if any resources failed to load during map rendering.
+
 ### `layers`
 
 An array of layer configurations.  Layers are rendered from tiled imagery or from a single image.

--- a/src/tile-layer.js
+++ b/src/tile-layer.js
@@ -19,6 +19,7 @@ function TileLayer(config) {
   this.onTileLoad = config.onTileLoad;
   this.onLoad = config.onLoad;
   this.loadedTiles = [];
+  this.error = null;
 }
 
 TileLayer.prototype.load = function() {
@@ -37,14 +38,19 @@ TileLayer.prototype.load = function() {
   }
 };
 
-TileLayer.prototype.handleTileLoad = function(err, tile) {
+TileLayer.prototype.handleTileLoad = function(error, tile) {
+  if (error) {
+    this.error = error;
+  }
   --this.loading;
   if (tile) {
     this.loadedTiles.push(tile);
-    this.onTileLoad();
+    if (this.onTileLoad) {
+      this.onTileLoad(error);
+    }
   }
   if (!this.loading && this.onLoad) {
-    this.onLoad();
+    this.onLoad(this.error);
   }
 };
 

--- a/src/untiled-layer.js
+++ b/src/untiled-layer.js
@@ -15,10 +15,10 @@ UntiledLayer.prototype.load = function() {
   return untile.load(this.handleUntileLoad.bind(this));
 };
 
-UntiledLayer.prototype.handleUntileLoad = function(err, untile) {
-  if (untile) {
-    this.untile = untile;
-    this.onLoad();
+UntiledLayer.prototype.handleUntileLoad = function(error, untile) {
+  this.untile = untile;
+  if (this.onLoad) {
+    this.onLoad(error);
   }
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,9 @@ exports.resolveDimensions = function(config) {
   var minMapBbox = config.bbox;
   var minMapWidth = bbox.width(minMapBbox);
   var minMapHeight = bbox.height(minMapBbox);
+  if (minMapWidth <= 0 || minMapHeight <= 0) {
+    throw new Error('Map must have non-empty bbox');
+  }
   var width, height, widthResolution, heightResolution, resolution;
   if (config.width) {
     width = config.width;

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -26,6 +26,19 @@ describe('constructor', function() {
     expect(call).to.throw(Error, /must have fit or clip/);
   });
 
+  it('throws if bbox is empty', function() {
+    var call = function() {
+      return new StickyMap({
+        fit: [10, -10, 10, -10],
+        width: 100,
+        height: 100,
+        layers: []
+      });
+    };
+
+    expect(call).to.throw(Error, /must have non-empty bbox/);
+  });
+
   it('throws if width and height are missing', function() {
     var call = function() {
       return new StickyMap({


### PR DESCRIPTION
This adds an `onLoad` callback to the map config.  The callback is called with an `Error` if anything fails during map rendering.